### PR TITLE
replaced facet formula syntax with rows()/cols()/facets()

### DIFF
--- a/html/data-visualization.qmd
+++ b/html/data-visualization.qmd
@@ -532,22 +532,22 @@ Facets divide a plot into subplots based on the values of one or more discrete v
 t <- ggplot(mpg, aes(cty, hwy)) + geom_point()
 ```
 
--   `t + facet_grid(. ~ fl)`: Facet into a column based on fl.
+-   `t + facet_grid(cols = vars(fl))`: Facet into a column based on fl.
 
--   `t + facet_grid(year ~ .)`: Facet into rows based on year.
+-   `t + facet_grid(rows = vars(year))`: Facet into rows based on year.
 
--   `t + facet_grid(year ~ fl)`: Facet into both rows and columns.
+-   `t + facet_grid(rows = vars(year), cols = vars(fl))`: Facet into both rows and columns.
 
--   `t + facet_wrap(~ fl)`: Wrap facets into a rectangular layout.
+-   `t + facet_wrap(facets = vars(fl))`: Wrap facets into a rectangular layout.
 
--   `t + facet_grid(drv ~ fl, scales = "free")`: Set **scales** to let axis limits vary across facets.
+-   `t + facet_grid(rows = vars(drv), cols = vars(fl), scales = "free")`: Set **scales** to let axis limits vary across facets.
     Also `"free_x"` for x axis limits adjust to individual facets and `"free_y"` for y axis limits adjust to individual facets.
 
 Set **labeller** to adjust facet label:
 
--   `t + facet_grid(. ~ fl, labeller = label_both)`: Labels each facet as "fl: c", "fl: d", etc.
+-   `t + facet_grid(cols = vars(fl), labeller = label_both)`: Labels each facet as "fl: c", "fl: d", etc.
 
--   `t + facet_grid(fl ~ ., labeller = label_bquote(alpha ^ .(fl)))`: Labels each facet as "𝛼^c^", "𝛼^d^", etc.
+-   `t + facet_grid(rows = vars(fl), labeller = label_bquote(alpha ^ .(fl)))`: Labels each facet as "𝛼^c^", "𝛼^d^", etc.
 
 ## Labels and Legends
 


### PR DESCRIPTION
removed deprecated formula calls from facets examples, used vars(...) instead
I came across this today while teaching ggplot and pointing participants to the cheatsheet. They got confused with the ~ syntax.

<!-- Thank you for contributing a cheatsheet! 🎉   
Cheatsheets are usually added in bursts so don't worry if your pull request sits for a little bit! 
Please fill out whichever section is relevant below and feel free to delete the irrelevant option. -->

