### PR TITLE
Fix 'Read a subset of lines' code example in html cheatsheet

### DIFF
--- a/html/data-import.qmd
+++ b/html/data-import.qmd
@@ -245,7 +245,7 @@ write_file("A,B,C\n7,8,9\nNA,11,12", file = "file3.csv")
     ```{r}
     #| message: false
 
-    read_csv("file.csv", skip = 1)
+    read_csv("file.csv", n_max = 1)
     ```
 
 -   Read values as missing:


### PR DESCRIPTION
Quick fix for the 'data-import' html cheatsheet, which has the wrong code for the 'Read a subset of lines' example.